### PR TITLE
AC-162: Fix reply functionality in Lerty node

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# deploy-local.sh - Deploy n8n-nodes-lerty to local container
+
+echo "🔨 Building n8n-nodes-lerty..."
+cd ~/dev/n8n-nodes-lerty && npm run build
+
+if [ $? -ne 0 ]; then
+    echo "❌ Build failed!"
+    exit 1
+fi
+
+echo "📦 Copying files to container mount..."
+cp -r ~/dev/n8n-nodes-lerty/dist/* ~/dev/licensed/custom-nodes/n8n-nodes-lerty/dist/
+
+echo "🔄 Restarting n8n container..."
+cd ~/dev/licensed && docker compose restart n8n
+
+echo "✅ Deployment complete!"
+echo "📋 Check logs with: cd ~/dev/licensed && docker compose logs -f n8n"

--- a/nodes/LertyTrigger/LertyTrigger.node.ts
+++ b/nodes/LertyTrigger/LertyTrigger.node.ts
@@ -232,6 +232,7 @@ export class LertyTrigger implements INodeType {
     const headers = this.getHeaderData() as IDataObject;
     const eventTypes = this.getNodeParameter('eventTypes', []) as string[];
     const additionalFields = this.getNodeParameter('additionalFields', {}) as IDataObject;
+    const agentId = this.getNodeParameter('agentId') as string;
 
     // Validate secret token if provided
     if (additionalFields.secretToken) {
@@ -256,12 +257,25 @@ export class LertyTrigger implements INodeType {
       };
     }
 
+    // Enrich the output with agent_id and other useful metadata
+    const outputData = {
+      ...body,
+      agent_id: agentId,
+      // Ensure conversation_id is available (handle different field names)
+      conversation_id: body.conversation_id || body.conversationId || body.thread_id,
+      // Ensure response_webhook is available if it exists
+      response_webhook: body.response_webhook || body.responseWebhook || body.callback_url,
+    };
+    
+    // Log what we're outputting for debugging
+    console.log('LertyTrigger output:', JSON.stringify(outputData, null, 2));
+
     // Return the data to the workflow
     return {
       workflowData: [
         [
           {
-            json: body,
+            json: outputData,
             headers,
           },
         ],


### PR DESCRIPTION
## Summary
- Fixed the replyToConversation function to properly send responses back to Lerty
- Added proper webhook URL handling using response_webhook from incoming messages
- Enhanced trigger node output to include necessary fields for reply mapping

## Changes
- Updated replyToConversation to use the response_webhook URL provided in incoming messages
- Added agent_id to LertyTrigger output for proper field mapping in workflows
- Implemented fallback logic when response_webhook is missing
- Added comprehensive logging for debugging
- Updated message format to match Lerty API expectations (conversation_id vs conversationId)
- Added deployment documentation and script for local container testing

## Testing
- Tested with local n8n container successfully sending and receiving messages
- Verified response_webhook URL is properly extracted and used
- Confirmed fallback behavior when response_webhook is missing

## Deployment Notes
- Added CLAUDE.md documentation for local container deployment process
- Created deploy-local.sh script for one-command deployment
- Critical: After building, files must be copied to the mounted volume directory

Fixes AC-162