### PR TITLE
Fix reply to conversation 403 error - correct payload format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-lerty",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-lerty",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-lerty",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "n8n community node for Lerty AI platform integration",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
## Summary
- Fixed 403 Forbidden error in replyToConversation action
- Changed request format from JSON to form-urlencoded to match API expectations
- Added automatic retrieval of user_id and organization_id from trigger data

## Problem
The replyToConversation action was failing with a 403 error because:
1. The API expects form-urlencoded data but was receiving JSON
2. Required fields (user_id, organization_id) were empty when using expression references

## Solution
1. **Payload Format**: Changed from `application/json` to `application/x-www-form-urlencoded` using URLSearchParams
2. **Field Resolution**: Added logic to retrieve user_id and organization_id from the Lerty Trigger workflow data when not present in current input
3. **Compatibility**: Ensures the implementation matches the standard workflow format shown in the reference workflow file

## Technical Details
- Uses URLSearchParams to properly format form data
- Implements fallback lookup for required fields from workflow trigger data
- Maintains compatibility with both direct trigger connections and expression-based references

## Test Plan
- [x] Verified payload format matches standard workflow
- [x] Tested with expression-based field references
- [x] Confirmed user_id and organization_id are properly populated
- [x] Validated 403 error is resolved

## Related
- Builds on PR #2 which added typing indicator support and initial webhook resolution fixes